### PR TITLE
Fix transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,8 +485,8 @@ contract EtherGame {
         require(this.balance == finalMileStone);
         // ensure there is a reward to give
         require(redeemableEther[msg.sender] > 0); 
-        uint transferValue = balances[msg.sender];
-        balances[msg.sender] = 0;
+        uint transferValue = redeemableEther[msg.sender];
+        redeemableEther[msg.sender] = 0;
         msg.sender.transfer(transferValue);
     }
  }    
@@ -541,9 +541,9 @@ contract EtherGame {
         require(depositedWei == finalMileStone);
         // ensure there is a reward to give
         require(redeemableEther[msg.sender] > 0); 
-    uint transferValue = balances[msg.sender];
-    balances[msg.sender] = 0;
-    msg.sender.transfer(transferValue);
+        uint transferValue = redeemableEther[msg.sender];
+        redeemableEther[msg.sender] = 0;
+        msg.sender.transfer(transferValue);
     }
  }    
 ```

--- a/README.md
+++ b/README.md
@@ -297,8 +297,9 @@ contract TimeLock {
         require(balances[msg.sender] > 0);
         require(now > lockTime[msg.sender]);
         uint balance = balances[msg.sender];
+        uint transferValue = balances[msg.sender];
         balances[msg.sender] = 0;
-        msg.sender.transfer(balance);
+        msg.sender.transfer(transferValue);
     }
 }
 ```
@@ -398,8 +399,9 @@ contract TimeLock {
     function withdraw() public {
         require(balances[msg.sender] > 0);
         require(now > lockTime[msg.sender]);
+        uint transferValue = balances[msg.sender];
         balances[msg.sender] = 0;
-        msg.sender.transfer(balances[msg.sender]);
+        msg.sender.transfer(transferValue);
     }
 }
 ```
@@ -483,8 +485,9 @@ contract EtherGame {
         require(this.balance == finalMileStone);
         // ensure there is a reward to give
         require(redeemableEther[msg.sender] > 0); 
-        redeemableEther[msg.sender] = 0;
-        msg.sender.transfer(redeemableEther[msg.sender]);
+        uint transferValue = balances[msg.sender];
+        balances[msg.sender] = 0;
+        msg.sender.transfer(transferValue);
     }
  }    
 ```
@@ -538,8 +541,9 @@ contract EtherGame {
         require(depositedWei == finalMileStone);
         // ensure there is a reward to give
         require(redeemableEther[msg.sender] > 0); 
-        redeemableEther[msg.sender] = 0;
-        msg.sender.transfer(redeemableEther[msg.sender]);
+    uint transferValue = balances[msg.sender];
+    balances[msg.sender] = 0;
+    msg.sender.transfer(transferValue);
     }
  }    
 ```


### PR DESCRIPTION
I was trying out the vulnerabilities shown in the article and found that on some transfers the balance was updated before the transfer was made:
```
balances[msg.sender] = 0;
msg.sender.transfer(balances[msg.sender]);
```
I think this solution might be better:
```
uint transferValue = balances[msg.sender];
balances[msg.sender] = 0;
msg.sender.transfer(transferValue);
```

Thank you so much for this article, I'm learning a lot from it.